### PR TITLE
fix: No return statement in function returning non-void

### DIFF
--- a/src/Ultrasonick.cpp
+++ b/src/Ultrasonick.cpp
@@ -48,5 +48,5 @@ int Ultrasonick::distanceRead() {
   by default, it will return the distance in centimeters.
   To change the default, replace CM by INC.
   */
-  distanceRead(CM);
+  return distanceRead(CM);
 }


### PR DESCRIPTION
The distanceRead () method must have the return statement explicit,
since in its signature returns int

Resolves: #14