### PR TITLE
Fix: Change the type of variable received as parameter in distanceRead()

### DIFF
--- a/src/Ultrasonick.cpp
+++ b/src/Ultrasonick.cpp
@@ -15,7 +15,7 @@
 
 #include "Ultrasonick.h"
 
-Ultrasonick::Ultrasonick(int trigPin, int echoPin) {
+Ultrasonick::Ultrasonick(uint8_t trigPin, uint8_t echoPin) {
   pinMode(trigPin, OUTPUT);
   pinMode(echoPin, INPUT);
   _trigPin = trigPin;
@@ -33,9 +33,8 @@ int Ultrasonick::timing() {
 
 /**
 * TODO: Enable the change of sound velocity constants
-* TODO: Change the variable type to a minnor size
 */
-int Ultrasonick::distanceRead(int und) {
+int Ultrasonick::distanceRead(uint8_t und) {
   if (und)
     return timing() / 28 / 2 ; //distance in CM
   else

--- a/src/Ultrasonick.h
+++ b/src/Ultrasonick.h
@@ -22,13 +22,13 @@
 */
 class Ultrasonick {
   public:
-    Ultrasonick(int trigPin, int echoPin);
-    int distanceRead(int und);
+    Ultrasonick(uint8_t trigPin, uint8_t echoPin);
+    int distanceRead(uint8_t und);
     int distanceRead();
 
   private:
-    int _trigPin;
-    int _echoPin;
+    uint8_t _trigPin;
+    uint8_t _echoPin;
     int timing();
 };
 


### PR DESCRIPTION
The type uint8_t was defined for the received parameters in the
reading method and for the internal variables.

Resolves: #8