### PR TITLE
Fix: Remove duplicate include from Arduino.h

### DIFF
--- a/src/Ultrasonick.h
+++ b/src/Ultrasonick.h
@@ -7,12 +7,6 @@
 #ifndef Ultrasonick_h
 #define Ultrasonick_h
 
-#if (ARDUINO >= 100)
-  #include "Arduino.h"
-#else
-  #include "WProgram.h"
-#endif
-
 #define CM 1
 #define INC 0
 


### PR DESCRIPTION
The include is only required in the .cpp file.

Resolves: #18