### PR TITLE
Fix: Old Arduino API suport

### DIFF
--- a/src/Ultrasonick.cpp
+++ b/src/Ultrasonick.cpp
@@ -4,15 +4,7 @@
   Released into the Creative Commons Attribution-ShareAlike 4.0 International.
 */
 
-/**
-* TODO: Consider removing compatibility for the old Arduino API
-*/
-#if (ARDUINO >= 100)
-  #include "Arduino.h"
-#else
-  #include "WProgram.h"
-#endif
-
+#include <Arduino.h>
 #include "Ultrasonick.h"
 
 Ultrasonick::Ultrasonick(uint8_t trigPin, uint8_t echoPin) {


### PR DESCRIPTION
The old API ("_WProgram.h_") is outdated and may be unstable.
Only adopt "_Arduino.h_" is more secure.

Resolves: #6 